### PR TITLE
自己紹介ページの追加

### DIFF
--- a/maniwa.html
+++ b/maniwa.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>自己紹介 - 真庭 詩音</title>
+  <style>
+    body {
+      font-family: 'Helvetica Neue', 'Arial', sans-serif;
+      background: linear-gradient(135deg, #ffe6f0, #fce4ec);
+      color: #4b2c35;
+      margin: 0;
+      padding: 40px 20px;
+      background-attachment: fixed;
+    }
+
+    .container {
+      max-width: 700px;
+      margin: 0 auto;
+      padding: 30px;
+      border-radius: 20px;
+
+      /* ガラス風 */
+      background: rgba(255, 255, 255, 0.25);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+
+      /* ピンクの枠 */
+      border: 2px solid #f8a6c2;
+    }
+
+    h1 {
+      text-align: center;
+      color: #d36a98;
+      font-size: 2em;
+      margin-bottom: 10px;
+    }
+
+    h2 {
+      color: #d36a98;
+      border-bottom: 2px solid #f9cddc;
+      padding-bottom: 5px;
+      margin-top: 30px;
+    }
+
+    p {
+      font-size: 1.1em;
+      line-height: 1.6;
+      margin: 10px 0;
+    }
+
+    strong {
+      color: #ba4d7a;
+    }
+
+    ul {
+      padding-left: 20px;
+    }
+
+    a {
+      color: #d36a98;
+      text-decoration: none;
+      font-weight: bold;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    .emoji {
+      font-size: 1.4em;
+      margin-right: 5px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>🌸 こんにちは！</h1>
+    <p><strong class="emoji">👤 名前：</strong> 真庭 詩音（まにわ しおん）</p>
+    <p><strong class="emoji">🏫 所属：</strong> 中央情報大学校 高度ICTデザイン学科 2年</p>
+    <p><strong class="emoji">💡 得意なこと：</strong> AI活用、Web開発、アプリ開発（Flutter）</p>
+    <p><strong class="emoji">🎮 趣味：</strong> Flutterアプリ開発、デザイン作成</p>
+
+    <h2>📮 連絡先</h2>
+    <ul>
+      <li><a href="mailto:f24aa020@chuo.ac.jp">f24aa020@chuo.ac.jp</a></li>
+    </ul>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
以下の内容で自己紹介ページを作成しました。

### ✅ 主な変更内容
- `index.html` を新規追加
- 名前／所属／得意なこと／趣味／連絡先を表示
- デザインテーマ：淡いピンク系 + ガラス風背景（backdrop-filter使用）
- ボーダー：ピンクの2px枠を追加して可愛い印象に

### 💡 補足
スマホ表示にも対応できるよう max-width を指定し、中央に配置しています。
必要があれば画像やアニメーションの追加も検討できます。
